### PR TITLE
Click did not pull in click-plugins, so it would fail unless I added …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires=[
         'requests>=2.0',
         'click>=6.7',
+        'click-plugins',
         'msgpack',
         'mock',
         'jinja2',


### PR DESCRIPTION
…it manually.

 [...] File "/Users/jj/src/git/safespring/python-jerakia/jerakia/cli.py", line 11, in <module>
    from click_plugins import with_plugins
ImportError: No module named click_plugins

...
pip install click_plugins
..
jerakia lookup --help

Usage: jerakia lookup [OPTIONS] NAMESPACE KEY